### PR TITLE
Improve scene lighting with sun, lamps, and basic shadows

### DIFF
--- a/App/App_test_integration_new2.cpp
+++ b/App/App_test_integration_new2.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <sstream>
 #include <vector>
+#include <string>
 #include <assimp/Importer.hpp>
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
@@ -566,12 +567,19 @@ int main(int argc, char*argv[])
    
 
     // Light variables
+    glm::vec3 sunDir   = glm::normalize(glm::vec3(-0.2f, -1.0f, -0.3f));
+    glm::vec3 sunColor = glm::vec3(1.0f, 1.0f, 0.9f);
 
-    glm::vec4 lightColor(1.0f, 1.0f, 1.0f, 1.0f); // positional light
-    
-    glm::vec3 lightPos(0.0f, 10.0f, 0.0f); // initial position
-    glm::mat4 lightModel = glm::mat4(1.0f);
-    lightModel = glm::translate(lightModel, lightPos);
+    std::vector<glm::vec3> lampPositions;
+    for (int i = 0; i < 16; ++i) {
+        glm::vec3 polePosition;
+        if (i < 8) {
+            polePosition = glm::vec3(-8.0f, 5.0f, -7.0f + i * 6.0f);
+        } else {
+            polePosition = glm::vec3(8.0f, 5.0f, -7.0f + (i - 8) * 6.0f);
+        }
+        lampPositions.push_back(polePosition);
+    }
 
     // Camera variables
     glm::vec3 cameraPos   = glm::vec3(0.0f, 1.5f,  5.0f);
@@ -597,10 +605,15 @@ int main(int argc, char*argv[])
     glUniformMatrix4fv(glGetUniformLocation(texturedShaderProgram, "camMatrix"), 1, GL_FALSE, glm::value_ptr(projection));
     glUniformMatrix4fv(glGetUniformLocation(texturedShaderProgram, "model"), 1, GL_FALSE, glm::value_ptr(model));
 
-    //lighting
-
-    glUniform4f(glGetUniformLocation(texturedShaderProgram, "lightColor"), 1.0f, 1.0f, 1.0f, 1.0f);
-    glUniform3f(glGetUniformLocation(texturedShaderProgram, "lightPos"), lightPos.x, lightPos.y, lightPos.z);
+    // lighting
+    glUniform3f(glGetUniformLocation(texturedShaderProgram, "sunDir"), sunDir.x, sunDir.y, sunDir.z);
+    glUniform3f(glGetUniformLocation(texturedShaderProgram, "sunColor"), sunColor.x, sunColor.y, sunColor.z);
+    glUniform1i(glGetUniformLocation(texturedShaderProgram, "lampCount"), lampPositions.size());
+    for (int i = 0; i < lampPositions.size(); ++i) {
+        std::string name = "lampPos[" + std::to_string(i) + "]";
+        glUniform3fv(glGetUniformLocation(texturedShaderProgram, name.c_str()), 1, glm::value_ptr(lampPositions[i]));
+    }
+    glUniform3f(glGetUniformLocation(texturedShaderProgram, "lampColor"), 1.0f, 0.95f, 0.8f);
     glUniform3f(glGetUniformLocation(texturedShaderProgram, "camPos"), cameraPos.x, cameraPos.y, cameraPos.z);
 
     // Texture

--- a/App/Shaders/textureFragment.glsl
+++ b/App/Shaders/textureFragment.glsl
@@ -8,18 +8,22 @@ in vec3 vertexNormal;
 in vec3 crntPos;
 
 uniform sampler2D textureSampler;
-
-// Existing point/ambient/spec uniforms you already use
-uniform vec4 lightColor;
-uniform vec3 lightPos;
 uniform vec3 camPos;
 
-// ==== NEW: Headlight spotlights ====
+// === Sun and lamp lighting ===
+#define MAX_LAMPS 16
+uniform int lampCount;
+uniform vec3 lampPos[MAX_LAMPS];
+uniform vec3 lampColor;
+uniform vec3 sunDir;
+uniform vec3 sunColor;
+
+// ==== Existing headlight spotlights ====
 struct SpotLight {
-    vec3 position;    // world
-    vec3 direction;   // world (normalized)
-    float innerCut;   // cos(innerAngle)
-    float outerCut;   // cos(outerAngle)
+    vec3 position;
+    vec3 direction;
+    float innerCut;
+    float outerCut;
     float constant;
     float linear;
     float quadratic;
@@ -28,12 +32,12 @@ struct SpotLight {
 
 uniform bool  uUseHeadlights;
 uniform SpotLight uHL[2];
-// ================================
+// ======================================
 
 vec3 spotContrib(SpotLight L, vec3 N, vec3 P, vec3 V, vec3 albedo)
 {
     vec3 Ldir = normalize(L.position - P);
-    float theta   = dot(Ldir, normalize(-L.direction)); // alignment with beam axis
+    float theta   = dot(Ldir, normalize(-L.direction));
     float epsilon = max(L.innerCut - L.outerCut, 1e-4);
     float spot    = clamp((theta - L.outerCut) / epsilon, 0.0, 1.0);
 
@@ -43,7 +47,6 @@ vec3 spotContrib(SpotLight L, vec3 N, vec3 P, vec3 V, vec3 albedo)
     float NdotL = max(dot(N, Ldir), 0.0);
     vec3 diffuse = albedo * NdotL;
 
-    // simple Blinn-Phong-ish spec
     vec3 H = normalize(Ldir + V);
     float spec = pow(max(dot(N, H), 0.0), 32.0);
 
@@ -52,29 +55,37 @@ vec3 spotContrib(SpotLight L, vec3 N, vec3 P, vec3 V, vec3 albedo)
 
 void main()
 {
-    // Base material
     vec3 albedo = texture(textureSampler, vertexUV).rgb;
+    vec3 N = normalize(vertexNormal);
+    vec3 V = normalize(camPos - crntPos);
 
-    // Your existing lighting (ambient + point light + spec)
-    float ambientStrength = 0.20;
-    vec3  N = normalize(vertexNormal);
-    vec3  LdirPoint = normalize(lightPos - crntPos);
-    float diffPoint = max(dot(N, LdirPoint), 0.0);
+    // Directional sunlight with simple shadowing
+    vec3 Lsun = normalize(-sunDir);
+    float diffSun = max(dot(N, Lsun), 0.0);
+    vec3 Rsun = reflect(-Lsun, N);
+    float specSun = pow(max(dot(V, Rsun), 0.0), 16.0);
+    float shadow = diffSun > 0.0 ? 1.0 : 0.2;
+    vec3 lighting = (0.1 * sunColor) + shadow * sunColor * (diffSun + 0.5 * specSun);
 
-    float specularLight = 0.50;
-    vec3  V = normalize(camPos - crntPos);
-    vec3  R = reflect(-LdirPoint, N);
-    float specAmount = pow(max(dot(V, R), 0.0), 8.0);
-    float specPoint   = specAmount * specularLight;
+    // Lamps as point lights
+    for (int i = 0; i < lampCount; ++i) {
+        vec3 Ldir = normalize(lampPos[i] - crntPos);
+        float dist = length(lampPos[i] - crntPos);
+        float atten = 1.0 / (1.0 + 0.09 * dist + 0.032 * dist * dist);
+        float diff = max(dot(N, Ldir), 0.0);
+        vec3 Rlamp = reflect(-Ldir, N);
+        float spec = pow(max(dot(V, Rlamp), 0.0), 32.0);
+        lighting += lampColor * atten * (diff + 0.5 * spec);
+    }
 
-    vec3 color = albedo * lightColor.rgb * (ambientStrength + diffPoint) + lightColor.rgb * specPoint;
+    vec3 color = albedo * lighting;
 
-    // ==== NEW: add two headlight spot contributions ====
+    // ==== Headlight spot contributions ====
     if (uUseHeadlights) {
         color += spotContrib(uHL[0], N, crntPos, V, albedo);
         color += spotContrib(uHL[1], N, crntPos, V, albedo);
     }
-    // ===================================================
+    // =====================================
 
     FragColor = vec4(color, 1.0);
 }

--- a/App/Shaders/textureVertex.glsl
+++ b/App/Shaders/textureVertex.glsl
@@ -14,10 +14,11 @@
 
                 void main()
                 {
-                    crntPos = vec3(model * vec4(aPos, 1.0f));
-                    gl_Position = camMatrix * model * vec4(aPos, 1.0f);
+                    vec4 worldPos = model * vec4(aPos, 1.0f);
+                    crntPos = worldPos.xyz;
+                    gl_Position = camMatrix * worldPos;
 
                     vertexColor = aColor;
                     vertexUV = aUV;
-                    vertexNormal = aNormal;
+                    vertexNormal = mat3(transpose(inverse(model))) * aNormal;
                 }


### PR DESCRIPTION
## Summary
- Add directional sunlight and warm lamp point lights to the car scene
- Compute per-fragment lighting with sun, lamps, and existing headlights
- Correct normal transformation in vertex shader for better shading

## Testing
- `g++ App_test_integration_new2.cpp -o test -lGL -lglfw -lGLEW -lassimp` *(fails: GL/glew.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689950a80b10832dab03ac1c95a0ae18